### PR TITLE
chore: update dependabot title format

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,5 +10,5 @@ updates:
     schedule:
       interval: "weekly"
     commit-message:
-      prefix: "chore(deps)"
+      prefix: "chore"
       include: "scope"


### PR DESCRIPTION
Update Dependabot's title format to match the Angular scope format.